### PR TITLE
Fix wrong search query in subject

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -38,7 +38,7 @@ class Inertia
             'props' => array_merge($props, self::getSharedProps()),
             'url' => Str::start(Str::after(
                 request()->getUrl() . request()->getPath() . (request()->getQueryString() ? '?' . request()->getQueryString() : ''),
-                request()->getScheme() . '://' . request()->getHostWithPort()
+                request()->getUrl()
             ), '/'),
             'version' => static::getVersion(),
         ];


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->
If we use a standard port and try to search it for a string with mandatory port specification (function `getHostWithPort()`), the string will not be found. We need to either look for `getUrl()` in the subject or change the subject from `request()->getUrl()` to `request()->getScheme() . '://' . request()->getHostWithPort()` because the `getUrl()` function does not output the port if it is standard.

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [x] Yes
- [ ] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#1 
